### PR TITLE
Update clojurescript & deps. Add datascript & rum

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,13 @@
   :description "CLJSFiddle"
   :url "http://cljsfiddle.net"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2227"]
+                 [org.clojure/clojurescript "0.0-2850"]
                  [org.clojure/tools.reader "0.8.4"]
                  [org.clojure/core.match "0.2.1"]
-                 [org.clojure/core.async "0.1.303.0-886421-alpha"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.clojure/core.logic "0.8.7"]
                  [org.clojure/tools.macro "0.1.5"]
-                 [com.datomic/datomic-free "0.9.4815"]
+                 [com.datomic/datomic-free "0.9.5130"]
                  [ring/ring-jetty-adapter "1.3.0"]
                  [ring/ring-devel "1.3.0"]
                  [fogus/ring-edn "0.2.0"]
@@ -21,16 +21,19 @@
                  [environ "0.5.0"]
                  [com.taoensso/timbre "3.2.1"]
                  [hylla "0.2.0"]
-                 [domina "1.0.2"]
-                 [prismatic/dommy "0.1.2"]
+                 [domina "1.0.3"]
+                 [prismatic/dommy "1.0.0"]
+                 [org.omcljs/om "0.8.8"]
+                 [reagent "0.5.0-alpha3"]
+                 [quiescent "0.1.4"]
                  [hiccups "0.3.0"]
-                 [cljs-ajax "0.2.4"]
-                 [om "0.6.4"]
-                 [quiescent "0.1.3"]
-                 [reagent "0.4.2"]]
+                 [cljs-ajax "0.3.10"]
+                 [rum "0.2.5"]
+                 [datascript "0.9.0"]
+]
   :source-paths ["src/clj" "src/cljs"]
   :plugins [[lein-ring "0.8.10"]
-            [lein-cljsbuild "1.0.3"]]
+            [lein-cljsbuild "1.0.4"]]
 ;  :main cljsfiddle.handler
 ;  :uberjar-name "cljsfiddle-standalone.jar"
   :min-lein-version "2.0.0"
@@ -43,7 +46,7 @@
                         :source-paths ["src/cljs"]
                         :compiler {:output-to "resources/public/js/app.js"
                                    :output-dir "resources/public/js/out-dev"
-                                   :source-map true
+                                   :source-map "resources/public/js/app.js.map"
                                    :optimizations :simple
                                    :pretty-print true}}
                        :prod {

--- a/src/clj/cljsfiddle/compiler.clj
+++ b/src/clj/cljsfiddle/compiler.clj
@@ -1,0 +1,17 @@
+(ns cljsfiddle.compiler
+  (:require [cljs.closure :as closure]
+            [cljs.js-deps :as deps]
+            [cljs.env :as cljs-env]
+            [cljs.compiler :as compiler]))
+
+
+(let [ups-deps (closure/get-upstream-deps)
+      opts {:ups-libs (:libs ups-deps)
+            :ups-foreign-libs (:foreign-libs ups-deps)
+            :ups-externs (:externs ups-deps)}
+
+     env (cljs-env/default-compiler-env opts)]
+
+    (swap! env assoc :js-dependency-index (deps/js-dependency-index opts))
+
+   (def compiler-env env))

--- a/src/clj/cljsfiddle/views.clj
+++ b/src/clj/cljsfiddle/views.clj
@@ -1,7 +1,7 @@
 (ns cljsfiddle.views
   (:require [hiccup.util :refer (escape-html)]
             [environ.core :refer (env)]
-            [cljsfiddle.closure :refer [compile-cljs*]]))
+            [cljsfiddle.db.util :refer [cljs-object-from-src]]))
 
 (def google-analytics-script
   "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -113,6 +113,11 @@
            [:a {:href "http://cljsfiddle.net"} "cljsfiddle.net"] " &copy; 2013 Jonas Enlund"]]]))
 
 (defn html-view [ns fiddle deps]
+  (let [cljs-obj (-> fiddle
+                       :cljsfiddle/cljs
+                       :cljsfiddle.src/blob
+                       :cljsfiddle.blob/text
+                       cljs-object-from-src)]
   [:html
    [:head
     [:title ns]
@@ -128,14 +133,10 @@
         :cljsfiddle.blob/text)
     [:script "CLOSURE_NO_DEPS=true;"]
     [:script "COMPILED=true;"]
+    [:script (:deps-src cljs-obj)]
     (for [dep deps]
       [:script {:src (str "/jscache/" (env :cljsfiddle-version) "/" dep)}])
-    [:script
-     (-> fiddle
-          :cljsfiddle/cljs
-          :cljsfiddle.src/blob
-          :cljsfiddle.blob/text
-          compile-cljs*)]]])
+    [:script (:js-src cljs-obj)]]]))
 
 (defn about-view [user]
   (base (navbar user)


### PR DESCRIPTION
- Reuse of `compiler-env` for faster increment re-compilation.
- Support of foreign-deps https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
- Fixed keywords with double colon prefix '::'

Latest change requires re-import database if
lib uses double colon keywords. (for `example` rum or `datascript`)
